### PR TITLE
データ移行に必要な処理をまとめた DataMigrationOperator の追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,38 @@ Dekiru.configure do |config|
 end
 ```
 
+## Data Migration Operator
+
+実行しながら進捗を表示したり、処理の最後に実行の確認をしたりといった、データ移行作業をするときに必要な処理を以下のような script を作成することで、実現できるようになります。
+
+```ruby
+# scripts/demo.rb
+Dekiru::DataMigrationOperator.execute('Demo migration') do
+  targets = User.where("email LIKE '%sonicgarden%'")
+
+  log "all targets count: #{targets.count}"
+  find_each_with_progress(targets) do |user|
+    user.update(admin: true)
+  end
+
+  log "updated user count: #{User.where("email LIKE '%sonicgarden%'").where(admin: true).count}"
+end
+```
+
+```
+$ bin/rails r scripts/demo.rb
+Start: Demo migration at 2019-05-24 18:29:57 +0900
+
+all targets count: 30
+Time: 00:00:00 |=================>>| 100% Progress
+updated user count: 30
+
+Are you sure to commit? (yes/no) > yes
+
+Finished successfully: Demo migration
+Total time: 6.35 sec
+```
+
 ## Contributing
 
 1.  Fork it

--- a/dekiru.gemspec
+++ b/dekiru.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'http_accept_language', [">= 2.0.0"]
   gem.add_dependency 'rails'
+  gem.add_dependency 'ruby-progressbar'
   gem.add_development_dependency 'rake', [">= 0"]
   gem.add_development_dependency 'rspec'
   gem.add_development_dependency 'rubocop'

--- a/lib/dekiru.rb
+++ b/lib/dekiru.rb
@@ -3,6 +3,7 @@ require 'dekiru/railtie' if defined?(::Rails)
 require 'dekiru/helper'
 require 'dekiru/controller_additions'
 require 'dekiru/validators/existence'
+require 'dekiru/data_migration_operator'
 require 'dekiru/mail_security_interceptor'
 
 require 'active_support'

--- a/lib/dekiru/data_migration_operator.rb
+++ b/lib/dekiru/data_migration_operator.rb
@@ -44,7 +44,6 @@ module Dekiru
     def find_each_with_progress(target_scope, options = {})
       opt = {
         format: '%a |%b>>%i| %p%% %t',
-        length: 50,
       }.merge(options).merge(
         total: target_scope.count,
         output: stream

--- a/lib/dekiru/data_migration_operator.rb
+++ b/lib/dekiru/data_migration_operator.rb
@@ -20,7 +20,7 @@ module Dekiru
     def execute(&block)
       @started_at = Time.current
       log "Start: #{title} at #{started_at}\n\n"
-      @result = ActiveRecord::Base.transaction do
+      @result = ActiveRecord::Base.transaction(requires_new: true) do
         instance_eval(&block)
         confirm?("\nAre you sure to commit?")
       end

--- a/lib/dekiru/data_migration_operator.rb
+++ b/lib/dekiru/data_migration_operator.rb
@@ -41,14 +41,15 @@ module Dekiru
       ((self.ended_at || Time.current) - self.started_at)
     end
 
-    def find_each_with_progress(target_scope, title: nil)
-      pb = ::ProgressBar.create(
-        title: title,
-        total: target_scope.count,
+    def find_each_with_progress(target_scope, options = {})
+      opt = {
         format: '%a |%b>>%i| %p%% %t',
         length: 50,
+      }.merge(options).merge(
+        total: target_scope.count,
         output: stream
       )
+      pb = ::ProgressBar.create(opt)
       target_scope.find_each do |target|
         yield target
         pb.increment

--- a/lib/dekiru/data_migration_operator.rb
+++ b/lib/dekiru/data_migration_operator.rb
@@ -1,0 +1,82 @@
+require 'ruby-progressbar'
+
+module Dekiru
+  class DataMigrationOperator
+    attr_reader :title, :stream, :result, :canceled, :started_at, :ended_at, :error
+
+    def self.execute(title, options = {}, &block)
+      self.new(title, options).execute(&block)
+    end
+
+    def initialize(title, options = {})
+      @title = title
+      @stream = options[:output] || $stdout
+    end
+
+    def log(message)
+      stream.puts(message)
+    end
+
+    def execute(&block)
+      @started_at = Time.current
+      log "Start: #{title} at #{started_at}\n\n"
+      @result = ActiveRecord::Base.transaction do
+        instance_eval(&block)
+        confirm?("\nAre you sure to commit?")
+      end
+      log "Finished successfully: #{title}" if @result == true
+    rescue => e
+      @error = e
+      @result = false
+    ensure
+      @ended_at = Time.current
+      log "Total time: #{self.duration.round(2)} sec"
+
+      raise error if error
+
+      return @result
+    end
+
+    def duration
+      ((self.ended_at || Time.current) - self.started_at)
+    end
+
+    def find_each_with_progress(target_scope, title: nil)
+      pb = ::ProgressBar.create(
+        title: title,
+        total: target_scope.count,
+        format: '%a |%b>>%i| %p%% %t',
+        length: 50,
+        output: stream
+      )
+      target_scope.find_each do |target|
+        yield target
+        pb.increment
+      end
+      pb.finish
+    end
+
+    def confirm?(message = 'Are you sure?')
+      loop do
+        stream.print "#{message} (yes/no) > "
+        case STDIN.gets.strip
+        when 'yes'
+          newline
+          return true
+        when 'no'
+          newline
+          cancel!
+        end
+      end
+    end
+
+    def newline
+      log ''
+    end
+
+    def cancel!
+      log "Canceled: #{title}"
+      raise ActiveRecord::Rollback
+    end
+  end
+end

--- a/lib/dekiru/version.rb
+++ b/lib/dekiru/version.rb
@@ -1,3 +1,3 @@
 module Dekiru
-  VERSION = '0.1.3'
+  VERSION = '0.1.4'
 end

--- a/spec/dekiru/data_migration_operator_spec.rb
+++ b/spec/dekiru/data_migration_operator_spec.rb
@@ -1,0 +1,113 @@
+require "spec_helper"
+
+describe Dekiru::DataMigrationOperator do
+  let(:dummy_stream) do
+    class Dekiru::DummyStream
+      attr_reader :out
+
+      def initialize
+        @out = ''
+      end
+
+      def puts(text)
+        @out = out << "#{text}\n"
+      end
+
+      def print(text)
+        @out = out << text
+      end
+
+      def tty?
+        false
+      end
+
+      def flush
+      end
+    end
+    Dekiru::DummyStream.new
+  end
+  let(:operator) { Dekiru::DataMigrationOperator.new('dummy', output: dummy_stream) }
+
+  describe '#execute' do
+    it 'confirm で yes' do
+      allow(STDIN).to receive(:gets) do
+        "yes\n"
+      end
+
+      expect do
+        operator.execute { log 'processing'; sleep 1.0 }
+      end.not_to raise_error
+
+      expect(operator.result).to eq(true)
+      expect(operator.duration).to be_within(0.1).of(1.0)
+      expect(operator.error).to eq(nil)
+      expect(operator.stream.out).to include('Are you sure to commit?')
+      expect(operator.stream.out).to include('Finished successfully:')
+      expect(operator.stream.out).to include('Total time:')
+    end
+
+    it 'confirm で no' do
+      allow(STDIN).to receive(:gets) do
+        "no\n"
+      end
+
+      expect do
+        operator.execute { log 'processing'; sleep 1.0 }
+      end.to raise_error(ActiveRecord::Rollback)
+
+      expect(operator.result).to eq(false)
+      expect(operator.duration).to be_within(0.1).of(1.0)
+      expect(operator.error.class).to eq(ActiveRecord::Rollback)
+      expect(operator.stream.out).to include('Are you sure to commit?')
+      expect(operator.stream.out).to include('Canceled:')
+      expect(operator.stream.out).to include('Total time:')
+    end
+
+    it '処理中に例外' do
+      expect do
+        operator.execute { raise ArgumentError }
+      end.to raise_error(ArgumentError)
+
+      expect(operator.result).to eq(false)
+      expect(operator.error.class).to eq(ArgumentError)
+      expect(operator.stream.out).not_to include('Are you sure to commit?')
+      expect(operator.stream.out).not_to include('Canceled:')
+      expect(operator.stream.out).to include('Total time:')
+    end
+  end
+
+  describe '#find_each_with_progress' do
+    it '進捗が表示される' do
+      class Dekiru::DummyRecord
+        def self.count
+          10
+        end
+
+        def self.find_each
+          (0...count).to_a.each do |num|
+            yield(num)
+          end
+        end
+      end
+
+      allow(STDIN).to receive(:gets) do
+        "yes\n"
+      end
+
+      sum = 0
+      operator.execute do
+        find_each_with_progress(Dekiru::DummyRecord, title: 'count up number') do |num|
+          sum += num
+        end
+      end
+
+      expect(sum).to eq(45)
+      expect(operator.result).to eq(true)
+      expect(operator.error).to eq(nil)
+      expect(operator.stream.out).to include('Are you sure to commit?')
+      expect(operator.stream.out).to include('count up number:')
+      expect(operator.stream.out).to include('Finished successfully:')
+      expect(operator.stream.out).to include('Total time:')
+    end
+  end
+end

--- a/spec/supports/mock_active_record.rb
+++ b/spec/supports/mock_active_record.rb
@@ -1,0 +1,5 @@
+class ActiveRecord::Base
+  def self.transaction
+    yield
+  end
+end

--- a/spec/supports/mock_active_record.rb
+++ b/spec/supports/mock_active_record.rb
@@ -1,5 +1,5 @@
 class ActiveRecord::Base
-  def self.transaction
-    yield
+  def self.transaction(*args)
+    yield(*args)
   end
 end


### PR DESCRIPTION
README から抜粋

----

## Data Migration Operator

実行しながら進捗を表示したり、処理の最後に実行の確認をしたりといった、データ移行作業をするときに必要な処理を以下のような script を作成することで、実現できるようになります。

```ruby
# scripts/demo.rb
Dekiru::DataMigrationOperator.execute('Demo migration') do
  targets = User.where("email LIKE '%sonicgarden%'")
  log "all targets count: #{targets.count}"
  find_each_with_progress(targets) do |user|
    user.update(admin: true)
  end
  log "updated user count: #{User.where("email LIKE '%sonicgarden%'").where(admin: true).count}"
end
```

```
$ bin/rails r scripts/demo.rb
Start: Demo migration at 2019-05-24 18:29:57 +0900
all targets count: 30
Time: 00:00:00 |=================>>| 100% Progress
updated user count: 30
Are you sure to commit? (yes/no) > yes
Finished successfully: Demo migration
Total time: 6.35 sec
```