### PR TITLE
fix: ruby@2.7 keyword deprecated warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ rvm:
   - 2.4.6
   - 2.5.5
   - 2.6.3
+  - 2.7.1
 
 # NOTE: https://github.com/travis-ci/travis-ci/issues/8978
 before_install:

--- a/lib/dekiru/helper.rb
+++ b/lib/dekiru/helper.rb
@@ -19,8 +19,8 @@ module Dekiru
       end
     end
 
-    def null_check_localization(*args)
-      localize(*args) if args.try(:first).present?
+    def null_check_localization(object, **options)
+      localize(object, **options) if object.present?
     end
     alias nl null_check_localization
 

--- a/lib/dekiru/version.rb
+++ b/lib/dekiru/version.rb
@@ -1,3 +1,3 @@
 module Dekiru
-  VERSION = '0.1.5'
+  VERSION = '0.1.6'
 end


### PR DESCRIPTION
https://github.com/rails/rails/blob/e3b8ba396bd2737ccc054178fda2e64ed20893e1/actionview/lib/action_view/helpers/translation_helper.rb#L151-L153