### PR TITLE
find_each_with_progress に total を渡せるようにする

### DIFF
--- a/lib/dekiru/data_migration_operator.rb
+++ b/lib/dekiru/data_migration_operator.rb
@@ -48,10 +48,11 @@ module Dekiru
     end
 
     def find_each_with_progress(target_scope, options = {})
+      total = options.delete(:total)
       opt = {
         format: '%a |%b>>%i| %p%% %t',
       }.merge(options).merge(
-        total: target_scope.count,
+        total: total || target_scope.count,
         output: stream
       )
       pb = ::ProgressBar.create(opt)

--- a/spec/dekiru/data_migration_operator_spec.rb
+++ b/spec/dekiru/data_migration_operator_spec.rb
@@ -127,5 +127,36 @@ describe Dekiru::DataMigrationOperator do
       expect(operator.stream.out).to include('Finished successfully:')
       expect(operator.stream.out).to include('Total time:')
     end
+
+    it 'total をオプションで渡すことができる' do
+      class Dekiru::DummyRecord
+        def self.count
+          raise "won't call"
+        end
+
+        def self.find_each
+          yield 99
+        end
+      end
+
+      allow(STDIN).to receive(:gets) do
+        "yes\n"
+      end
+
+      sum = 0
+      operator.execute do
+        find_each_with_progress(Dekiru::DummyRecord, title: 'pass total as option', total: 1) do |num|
+          sum += num
+        end
+      end
+
+      expect(sum).to eq(99)
+      expect(operator.result).to eq(true)
+      expect(operator.error).to eq(nil)
+      expect(operator.stream.out).to include('Are you sure to commit?')
+      expect(operator.stream.out).to include('pass total as option:')
+      expect(operator.stream.out).to include('Finished successfully:')
+      expect(operator.stream.out).to include('Total time:')
+    end
   end
 end


### PR DESCRIPTION
`count` できない scope でも使えるようにするための修正です。
`Child.joins(:parent).select('children.*, parents.parent_type')` のような scope を渡した場合に `count` の呼び出しで落ちてしまうのを、total オプションを使って回避できるようにすることを想定しています。

落ちる:
```
scope = Child.joins(:parent)
find_each_with_progress(scope.select('children.*, parents.parent_type'))
```

落ちない:
```
scope = Child.joins(:parent)
find_each_with_progress(scope.select('children.*, parents.parent_type'), total: scope.count)
```