### PR TITLE
selenium-webdriver gemのver4.3でManager#logsが削除されたためDriver#logsに置き換え

### DIFF
--- a/lib/dekiru/capybara/matchers.rb
+++ b/lib/dekiru/capybara/matchers.rb
@@ -3,7 +3,12 @@ module Dekiru
     module Matchers
       class JsNoErrorMatcher
         def matches?(page_or_logs)
-          logs = page_or_logs.respond_to?(:driver) ? page_or_logs.driver.browser.logs.get(:browser) : page_or_logs
+          logs = if page_or_logs.respond_to?(:driver)
+                   ActiveSupport::Deprecation.warn('[dekiru] call have_no_js_errors with page is deprecated. please call with logs.')
+                   page_or_logs.driver.browser.logs.get(:browser)
+                 else
+                   page_or_logs
+                 end
           logs.find_all { |log| log.level == 'WARNING' }.each do |log|
             STDERR.puts 'WARN: javascript warning'
             STDERR.puts log.message

--- a/lib/dekiru/capybara/matchers.rb
+++ b/lib/dekiru/capybara/matchers.rb
@@ -3,7 +3,7 @@ module Dekiru
     module Matchers
       class JsNoErrorMatcher
         def matches?(page_or_logs)
-          logs = page_or_logs.respond_to?(:driver) ? page_or_logs.driver.browser.manage.logs.get(:browser) : page_or_logs
+          logs = page_or_logs.respond_to?(:driver) ? page_or_logs.driver.browser.logs.get(:browser) : page_or_logs
           logs.find_all { |log| log.level == 'WARNING' }.each do |log|
             STDERR.puts 'WARN: javascript warning'
             STDERR.puts log.message


### PR DESCRIPTION
selenium-webdriver gemのver4.3でManager#logsが削除されたためDriver#logsに置き換え
https://github.com/SeleniumHQ/selenium/blob/7b1c6461f618fefcb8fec4a972bc7ec1abb47c34/rb/CHANGES#L11

関連コミット
- deprecated
https://github.com/SeleniumHQ/selenium/commit/0af5d6a52c7c76add80a770940faf71b25071354

- removed
https://github.com/SeleniumHQ/selenium/commit/8747489fa6c95f0cd1bbeef97f4848d57f3453ee